### PR TITLE
fix: keep default branch

### DIFF
--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -155,7 +155,7 @@
 
     const {
       data: { default_branch },
-    }= await octokit.repos.get({
+    } = await octokit.repos.get({
       owner,
       repo
     });

--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -12,6 +12,7 @@
     old: {type: "string", default: "master", description: "The name of the branch to rename"},
     new: {type: "string", default: "main", description: "The new branch name"},
     confirm: {type: "boolean", default: false, description: "Run without prompting for confirmation"},
+    keepDefault: {type: "boolean", default: false, description: "Retain the original default branch"}
   }).example([
     ["$0 --pat <token> --repo user/repo", "Rename master to main"],
     ["$0 --pat <token> --repo user/repo --old dev --new develop", "Rename dev to develop"],
@@ -149,11 +150,11 @@
       }
     }
 
-    if (argv.verbose) {
+    if (argv.verbose && !argv.keepDefault) {
       console.log(`✏️  Updating default branch to [${target}] in [${repo}]`);
     }
 
-    if (!isDryRun) {
+    if (!isDryRun && !argv.keepDefault) {
       // Update the default branch in the repo
       await octokit.repos.update({
         owner,

--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -154,12 +154,11 @@
     }
 
     const {
-      data: { default_branch },
+      data: { default_branch: defaultBranch },
     } = await octokit.repos.get({
       owner,
       repo
     });
-    const defaultBranch = default_branch;
 
     if (!isDryRun && defaultBranch === old) {
       // Update the default branch in the repo

--- a/bin/github-default-branch
+++ b/bin/github-default-branch
@@ -12,7 +12,6 @@
     old: {type: "string", default: "master", description: "The name of the branch to rename"},
     new: {type: "string", default: "main", description: "The new branch name"},
     confirm: {type: "boolean", default: false, description: "Run without prompting for confirmation"},
-    keepDefault: {type: "boolean", default: false, description: "Retain the original default branch"}
   }).example([
     ["$0 --pat <token> --repo user/repo", "Rename master to main"],
     ["$0 --pat <token> --repo user/repo --old dev --new develop", "Rename dev to develop"],
@@ -150,11 +149,19 @@
       }
     }
 
-    if (argv.verbose && !argv.keepDefault) {
+    if (argv.verbose) {
       console.log(`✏️  Updating default branch to [${target}] in [${repo}]`);
     }
 
-    if (!isDryRun && !argv.keepDefault) {
+    const {
+      data: { default_branch },
+    }= await octokit.repos.get({
+      owner,
+      repo
+    });
+    const defaultBranch = default_branch;
+
+    if (!isDryRun && defaultBranch === old) {
       // Update the default branch in the repo
       await octokit.repos.update({
         owner,


### PR DESCRIPTION
For repos where `master` is not the default branch, we want to keep the original default branch.

Example: chuck-resin-images uses `develop` as the default branch and the script would have made `main` the new default.